### PR TITLE
Copy useful links from Mac issue tracker homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@
 **Bug and issue tracker**  
 If you encountered a bug or have a feature request feel free to [create an issue](https://github.com/ForkIssues/TrackerWin/issues/new).
 </div>
+
+* [All issues](https://github.com/ForkIssues/TrackerWin/issues)
+* [Most popular issues](https://github.com/ForkIssues/TrackerWin/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ If you encountered a bug or have a feature request feel free to [create an issue
 
 * [All issues](https://github.com/ForkIssues/TrackerWin/issues)
 * [Most popular issues](https://github.com/ForkIssues/TrackerWin/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)
+* [Mac version issue tracker](https://github.com/ForkIssues/Tracker)


### PR DESCRIPTION
This PR adds links to All and Popular issues, exactly as per the Mac version.

As a separate commit in the PR I've added a link to the Mac issue tracker. I'd of course be happy to roll that commit back if you'd prefer not to have it .... or even to do the matching PR for the Mac version with a link to the Windows version if you'd like that too! 😊